### PR TITLE
feat：改进Turnstile Secret Key

### DIFF
--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -35,7 +35,7 @@ export async function GET() {
     turnstile: canManageConfig ? {
       enabled: turnstileEnabled === "true",
       siteKey: turnstileSiteKey || "",
-      secretKey: turnstileSecretKey || "",
+      secretKeyConfigured: Boolean(turnstileSecretKey),
     } : undefined
   })
 }
@@ -63,7 +63,8 @@ export async function POST(request: Request) {
     turnstile?: {
       enabled: boolean,
       siteKey: string,
-      secretKey: string
+      secretKey: string,
+      secretKeyChanged?: boolean
     }
   }
   
@@ -71,25 +72,34 @@ export async function POST(request: Request) {
     return Response.json({ error: "无效的角色" }, { status: 400 })
   }
 
+  const env = getRequestContext().env
+
   const turnstileConfig = turnstile ?? {
     enabled: false,
     siteKey: "",
-    secretKey: ""
+    secretKey: "",
+    secretKeyChanged: false,
   }
 
-  if (turnstileConfig.enabled && (!turnstileConfig.siteKey || !turnstileConfig.secretKey)) {
+  const nextTurnstileSiteKey = turnstileConfig.siteKey.trim()
+  const nextTurnstileSecretKey = turnstileConfig.secretKey.trim()
+  const existingTurnstileSecretKey = await env.SITE_CONFIG.get("TURNSTILE_SECRET_KEY") || ""
+  const turnstileSecretKeyToStore = turnstileConfig.secretKeyChanged
+    ? nextTurnstileSecretKey
+    : existingTurnstileSecretKey
+
+  if (turnstileConfig.enabled && (!nextTurnstileSiteKey || !turnstileSecretKeyToStore)) {
     return Response.json({ error: "Turnstile 启用时需要提供 Site Key 和 Secret Key" }, { status: 400 })
   }
 
-  const env = getRequestContext().env
   await Promise.all([
     env.SITE_CONFIG.put("DEFAULT_ROLE", defaultRole),
     env.SITE_CONFIG.put("EMAIL_DOMAINS", emailDomains),
     env.SITE_CONFIG.put("ADMIN_CONTACT", adminContact),
     env.SITE_CONFIG.put("MAX_EMAILS", maxEmails),
     env.SITE_CONFIG.put("TURNSTILE_ENABLED", turnstileConfig.enabled.toString()),
-    env.SITE_CONFIG.put("TURNSTILE_SITE_KEY", turnstileConfig.siteKey),
-    env.SITE_CONFIG.put("TURNSTILE_SECRET_KEY", turnstileConfig.secretKey)
+    env.SITE_CONFIG.put("TURNSTILE_SITE_KEY", nextTurnstileSiteKey),
+    env.SITE_CONFIG.put("TURNSTILE_SECRET_KEY", turnstileSecretKeyToStore)
   ])
 
   return Response.json({ success: true })

--- a/app/components/profile/website-config-panel.tsx
+++ b/app/components/profile/website-config-panel.tsx
@@ -29,6 +29,8 @@ export function WebsiteConfigPanel() {
   const [turnstileEnabled, setTurnstileEnabled] = useState(false)
   const [turnstileSiteKey, setTurnstileSiteKey] = useState("")
   const [turnstileSecretKey, setTurnstileSecretKey] = useState("")
+  const [turnstileSecretKeyConfigured, setTurnstileSecretKeyConfigured] = useState(false)
+  const [turnstileSecretKeyChanged, setTurnstileSecretKeyChanged] = useState(false)
   const [showSecretKey, setShowSecretKey] = useState(false)
   const [loading, setLoading] = useState(false)
   const { toast } = useToast()
@@ -49,7 +51,7 @@ export function WebsiteConfigPanel() {
         turnstile?: {
           enabled: boolean,
           siteKey: string,
-          secretKey?: string
+          secretKeyConfigured?: boolean
         }
       }
       setDefaultRole(data.defaultRole)
@@ -58,7 +60,9 @@ export function WebsiteConfigPanel() {
       setMaxEmails(data.maxEmails || EMAIL_CONFIG.MAX_ACTIVE_EMAILS.toString())
       setTurnstileEnabled(Boolean(data.turnstile?.enabled))
       setTurnstileSiteKey(data.turnstile?.siteKey ?? "")
-      setTurnstileSecretKey(data.turnstile?.secretKey ?? "")
+      setTurnstileSecretKey("")
+      setTurnstileSecretKeyConfigured(Boolean(data.turnstile?.secretKeyConfigured))
+      setTurnstileSecretKeyChanged(false)
     }
   }
 
@@ -76,12 +80,19 @@ export function WebsiteConfigPanel() {
           turnstile: {
             enabled: turnstileEnabled,
             siteKey: turnstileSiteKey,
-            secretKey: turnstileSecretKey
+            secretKey: turnstileSecretKey,
+            secretKeyChanged: turnstileSecretKeyChanged,
           }
         }),
       })
 
       if (!res.ok) throw new Error(t("saveFailed"))
+
+      setTurnstileSecretKeyConfigured(
+        turnstileSecretKeyChanged ? Boolean(turnstileSecretKey.trim()) : turnstileSecretKeyConfigured
+      )
+      setTurnstileSecretKey("")
+      setTurnstileSecretKeyChanged(false)
 
       toast({
         title: t("saveSuccess"),
@@ -194,8 +205,13 @@ export function WebsiteConfigPanel() {
                 id="turnstile-secret-key"
                 type={showSecretKey ? "text" : "password"}
                 value={turnstileSecretKey}
-                onChange={(e) => setTurnstileSecretKey(e.target.value)}
-                placeholder={t("turnstile.secretKeyPlaceholder")}
+                onChange={(e) => {
+                  setTurnstileSecretKey(e.target.value)
+                  setTurnstileSecretKeyChanged(true)
+                }}
+                placeholder={turnstileSecretKeyConfigured
+                  ? t("turnstile.secretKeyConfiguredPlaceholder")
+                  : t("turnstile.secretKeyPlaceholder")}
               />
               <Button
                 type="button"
@@ -208,7 +224,9 @@ export function WebsiteConfigPanel() {
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              {t("turnstile.secretKeyDescription")}
+              {turnstileSecretKeyConfigured
+                ? t("turnstile.secretKeyConfiguredDescription")
+                : t("turnstile.secretKeyDescription")}
             </p>
           </div>
         </div>

--- a/app/i18n/messages/en/profile.json
+++ b/app/i18n/messages/en/profile.json
@@ -114,7 +114,9 @@
       "siteKeyPlaceholder": "Enter Turnstile Site Key",
       "secretKey": "Secret Key",
       "secretKeyPlaceholder": "Enter Turnstile Secret Key",
-      "secretKeyDescription": "Set up a Turnstile application in Cloudflare and provide the required keys before enabling"
+      "secretKeyConfiguredPlaceholder": "Secret Key already configured; leave blank to keep it",
+      "secretKeyDescription": "Set up a Turnstile application in Cloudflare and provide the required keys before enabling",
+      "secretKeyConfiguredDescription": "A Secret Key is already stored; only fill this in to replace or clear it"
     },
     "save": "Save Configuration",
     "saving": "Saving...",

--- a/app/i18n/messages/ja/profile.json
+++ b/app/i18n/messages/ja/profile.json
@@ -114,7 +114,9 @@
       "siteKeyPlaceholder": "Turnstile Site Key を入力",
       "secretKey": "Secret Key",
       "secretKeyPlaceholder": "Turnstile Secret Key を入力",
-      "secretKeyDescription": "Cloudflare で Turnstile を作成し、必須のキーを入力してから有効化してください"
+      "secretKeyConfiguredPlaceholder": "Secret Key は設定済みです。変更しない場合は空欄のままにしてください",
+      "secretKeyDescription": "Cloudflare で Turnstile を作成し、必須のキーを入力してから有効化してください",
+      "secretKeyConfiguredDescription": "Secret Key はすでに保存されています。置き換えまたは削除する場合のみ入力してください"
     },
     "save": "設定を保存",
     "saving": "保存中...",

--- a/app/i18n/messages/ko/profile.json
+++ b/app/i18n/messages/ko/profile.json
@@ -114,7 +114,9 @@
       "siteKeyPlaceholder": "Turnstile Site Key 입력",
       "secretKey": "Secret Key",
       "secretKeyPlaceholder": "Turnstile Secret Key 입력",
-      "secretKeyDescription": "활성화하기 전에 Cloudflare에서 Turnstile 애플리케이션을 설정하고 필요한 키를 제공하세요"
+      "secretKeyConfiguredPlaceholder": "Secret Key가 이미 설정되어 있습니다. 유지하려면 비워 두세요",
+      "secretKeyDescription": "활성화하기 전에 Cloudflare에서 Turnstile 애플리케이션을 설정하고 필요한 키를 제공하세요",
+      "secretKeyConfiguredDescription": "현재 Secret Key가 저장되어 있습니다. 교체하거나 비울 때만 입력하세요"
     },
     "save": "설정 저장",
     "saving": "저장 중...",

--- a/app/i18n/messages/zh-CN/profile.json
+++ b/app/i18n/messages/zh-CN/profile.json
@@ -114,7 +114,9 @@
       "siteKeyPlaceholder": "输入 Turnstile Site Key",
       "secretKey": "Secret Key",
       "secretKeyPlaceholder": "输入 Turnstile Secret Key",
-      "secretKeyDescription": "开启前请先在 Cloudflare 创建 Turnstile，并填写上述必填参数"
+      "secretKeyConfiguredPlaceholder": "已配置 Secret Key，留空则保持不变",
+      "secretKeyDescription": "开启前请先在 Cloudflare 创建 Turnstile，并填写上述必填参数",
+      "secretKeyConfiguredDescription": "当前已保存 Secret Key；仅在需要替换或清空时再填写"
     },
     "save": "保存配置",
     "saving": "保存中...",

--- a/app/i18n/messages/zh-TW/profile.json
+++ b/app/i18n/messages/zh-TW/profile.json
@@ -114,7 +114,9 @@
       "siteKeyPlaceholder": "輸入 Turnstile Site Key",
       "secretKey": "Secret Key",
       "secretKeyPlaceholder": "輸入 Turnstile Secret Key",
-      "secretKeyDescription": "請先在 Cloudflare 建立 Turnstile 並填寫上述必填參數後再啟用"
+      "secretKeyConfiguredPlaceholder": "Secret Key 已設定，留空即可保留現有值",
+      "secretKeyDescription": "請先在 Cloudflare 建立 Turnstile 並填寫上述必填參數後再啟用",
+      "secretKeyConfiguredDescription": "目前已儲存 Secret Key；只有在要替換或清除時才需重新輸入"
     },
     "save": "儲存設定",
     "saving": "儲存中...",


### PR DESCRIPTION
这个拉取请求改进了网站配置面板中 **Turnstile Secret Key（密钥）** 的管理方式和用户体验。此次变更确保 Secret Key 能够以更安全、更直观的方式处理，使管理员可以在**不暴露密钥实际值**的情况下，选择保留、更新或清除该密钥。界面和后端逻辑也已更新，以正确反映该密钥是否已经配置，同时对翻译文案进行了优化，使表达更清晰。

**后端变更：**

* API 现在返回的是 `secretKeyConfigured` 布尔值，而不再返回实际的 Secret Key，因此密钥值不会在 API 响应中暴露。
* 在更新配置时，后端只有在用户明确修改了 Secret Key（通过新的 `secretKeyChanged` 标志）时，才会覆盖已存储的密钥；否则会保留现有密钥。验证逻辑也确保在启用 Turnstile 时，两个密钥都必须存在。

**前端逻辑与界面：**

* 配置面板现在会跟踪 Secret Key 是否已配置，以及用户是否对其进行了修改。输入框的占位提示和说明文字会根据这一状态动态调整，并且在保存后会清空输入框。
* 前端不再期望从 API 获取 Secret Key 的实际值，而是改为使用 `secretKeyConfigured` 标志来相应调整界面显示。

**国际化：**

* 已在所有支持的语言中新增并更新相关翻译，用于新的占位提示和说明文本，更清楚地说明 Secret Key 是否已经配置。
