### PR TITLE
Update Node.js version in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install Dependencies


### PR DESCRIPTION
修改 node.js 版本，构建的时候要求 22，之前是 20 会导致创建 workers 失败